### PR TITLE
Add scribbletune

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ A curated list of software, hardware, and other resources to create music.
 - [PitchFinder] & [Node PitchFinder] - Javascript (and node c++ addon) with pitch detection algorithms
 - [React Music] - Create beats with [React].
 - [Repitch] - Real-time polyphonic MIDI-controlled audio pitch shifting.
+- [Scribbletune] - Create music with JavaScript.
 - [Sharp11] - Music theorization and improvisation engine.
 - [Slang] - Simple audio programming language implemented in JavaScript.
 - [Spleeter] - Source separation library (e.g. extract drums from a track).
@@ -129,6 +130,7 @@ A curated list of software, hardware, and other resources to create music.
 [React Music]: https://github.com/FormidableLabs/react-music
 [Repitch]: https://github.com/maxwellpollack/repitch
 [React]: https://reactjs.org/
+[Scribbletune]: https://github.com/scribbletune/scribbletune
 [Sharp11]: https://github.com/jsrmath/sharp11
 [Slang]: http://slang.kylestetz.com
 [Spleeter]: https://github.com/deezer/spleeter


### PR DESCRIPTION
Sorry for the shameless plug, but hopefully the activity, contributors and features will help in considering this lib to be added. 

Scribbletune can be used to create the following:

- MIDI files from the terminal [using Node.js]
- Create music performance apps for the browser [with client JS]
- Create Max for Live devices to be used in Ableton Live

Repo: https://github.com/scribbletune/scribbletune
Website [with docs, videos, examples]: https://scribbletune.com/