### PR TITLE
remove 2 broken links and edit rebranded link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -367,16 +367,12 @@ Check it out at [leomask.com](https://leomask.com)
 ### AI Music Creation
 
 - [Amper]
-- [Jukedeck]
-- [Melodrive]
 - [Humtap]
-- [Popgun]
+- [Splash]
 
 [Amper]: https://www.ampermusic.com
-[Jukedeck]: https://www.jukedeck.com
-[Melodrive]: http://melodrive.com
 [Humtap]: https://www.humtap.com
-[Popgun]: https://popgun.ai
+[Splash]: https://www.splashhq.com
 
 
 ### Music Distribution


### PR DESCRIPTION
https://popgun.ai/ has rebranded to https://www.splashhq.com/ as you can see on the homepage.

the other 2 'ai music creation' links removed as one points to an expired shopify? link and the other is a parked domain as the owner let it expire.

minor edits but a start.