### PR TITLE
Update the list under Music Distribution, remove songriffer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -390,24 +390,20 @@ Check it out at [leomask.com](https://leomask.com)
 - [BandCamp]
 - [DistroKid]
 - [RecordJet]
-- [Spinnup]
+- [Amuse]
 
 [ReverbNation]: https://www.reverbnation.com
 [TuneCore]: https://www.tunecore.com
 [DittoMusic]: https://www.dittomusic.com
-[SoundCloud]: https://www.soundcloud.com
+[SoundCloud]: https://artists.soundcloud.com
 [Octiive]: https://www.octiive.com
 [BandCamp]: https://bandcamp.com
 [DistroKid]: https://distrokid.com
 [RecordJet]: https://www.recordjet.com
-[Spinnup]: https://spinnup.com
+[Amuse]: https://amuse.io
 
 
 ### Management
-
-- [SongRiffer] - Organize and browse riffs and song ideas.
-
-[SongRiffer]: https://songriffer.com/
 
 
 ## Datasets


### PR DESCRIPTION
- Spinup is closed (as per their website https://spinnup.com/)
- Soundcloud - updated the link to their music distribution landing page
- Added Amuse as one of the growing music distributors

Also songriffer seems pivoted towards digital money transfers so I removed it from the list.