### PR TITLE
Add MusicWall to services

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -399,6 +399,10 @@ Check it out at [leomask.com](https://leomask.com)
 
 ## Services
 
+- [MusicWall] - Free music landings for producers / engineers with Spotify credits
+
+[MusicWall]: https://musicwall.app
+
 ### AI Music Creation
 
 - [Amper]


### PR DESCRIPTION
Hi! [MusicWall](https://musicwall.app) is a **free service** for Music Producers / Audio Engineers to create and share portfolios with Spotify and YouTube credits with more than 150 active users.