### PR TITLE
Add Claude AI Music Skills to Software > Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -278,6 +278,9 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 - [Agordejo] - Music production session manager.
 - [Auxy] - Modern instruments for mobile creators.
 - [ChipTone] - Free tool for generating sound effects.
+- [Claude AI Music Skills] - Claude Code plugin for AI-assisted album production
+  including lyrics, style prompts, per-stem mixing, mastering,
+  and release management.
 - [Composer's Sketchpad] - Sequencer that combines musical staff paper with an artist's sketchbook (iOS only).
 - [Dragonfly Reverb] - Open source audio effects for Linux, macOS, and Windows.
 - [Fluajho] - Simple SF2 soundfont host and player for Linux.
@@ -307,6 +310,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 [Agordejo]: https://www.laborejo.org/agordejo/
 [Auxy]: http://auxy.co
 [ChipTone]: https://sfbgames.itch.io/chiptone
+[Claude AI Music Skills]: https://github.com/bitwize-music-studio/claude-ai-music-skills
 [Composer's Sketchpad]: http://composerssketchpad.com
 [Dragonfly Reverb]: https://github.com/michaelwillis/dragonfly-reverb
 [Fluajho]: https://www.laborejo.org/documentation/fluajho/english.html


### PR DESCRIPTION
Adds [Claude AI Music Skills](https://github.com/bitwize-music-studio/claude-ai-music-skills) to the Apps section under Software.

Claude Code plugin for AI-assisted album production covering lyrics, style prompts, per-stem mixing, mastering, and release management.