### PR TITLE
Add voicetoinstrument.com - AI voice to instrumental tracks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -430,6 +430,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 
 - [Landr] - Automatic audio mastering.
 - [Virtu] - Assisted mastering.
+- [voicetoinstrument.com](https://voicetoinstrument.com) - Convert voice to instrumental tracks using AI.
 
 [Landr]: https://www.landr.com
 [Virtu]: https://virtu.slatedigital.com


### PR DESCRIPTION
## voicetoinstrument.com
Convert voice to instrumental tracks using AI.

This PR adds voicetoinstrument.com to the SaaS section — an AI tool that converts voice recordings into instrumental tracks, useful for musicians and producers.