### PR TITLE
Add Grip (remote control app for Ableton Live)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -282,6 +282,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 - [Dragonfly Reverb] - Open source audio effects for Linux, macOS, and Windows.
 - [Fluajho] - Simple SF2 soundfont host and player for Linux.
 - [FreeEQ8] - Free, open-source 8-band parametric EQ plugin (VST3/AU) for macOS and Windows.
+- [Grip] - Hands-free voice & remote control for Ableton Live workflow.
 - [IXI Programs] - Apps for creating musical instruments and environments.
 - [JJazzLab] - Easily generate dynamic backing tracks for any song.
 - [Konfyt] - Digital keyboard workstation for Linux.
@@ -312,6 +313,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 [Fluajho]: https://www.laborejo.org/documentation/fluajho/english.html
 [FreeEQ8]: https://github.com/GareBear99/FreeEQ8
 [IXI Programs]: http://www.ixi-audio.net/content/software.html
+[Grip]: https://www.gripforlive.com/
 [JJazzLab]: https://www.jjazzlab.org/en/
 [Konfyt]: https://github.com/noedigcode/konfyt
 [KXStudio]: https://kx.studio


### PR DESCRIPTION
Grip is a remote control app for Ableton Live, to control it hands-free while recording. Includes transport controls, navigation, hands-free voice controls, undo/redo and save workflow, etc.