### PR TITLE
Add AceTagGen to AI Music Creation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -500,6 +500,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 
 ### AI Music Creation
 
+- [AceTagGen] - Free prompt-building toolkit for Suno AI; structured 12-step questionnaire + 3,000+ community-verified tags + quality scorer.
 - [LAIVE]
 - [LatentScore Live] - Generate ambient music from text in the browser.
 - [MemoTune] - Transform text or lyrics into full songs with AI vocals.
@@ -508,6 +509,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 - [Splash] - AI-powered music creation platform.
 - [Suno AI] - AI-powered music composition and production platform.
 
+[AceTagGen]: https://acetaggen.com
 [LAIVE]: https://www.laive.io
 [LatentScore Live]: https://latentscore.com
 [MemoTune]: https://memotune.com


### PR DESCRIPTION
Adds [AceTagGen](https://acetaggen.com) to the AI Music Creation section.

AceTagGen is a free, freemium prompt-building toolkit specifically for Suno AI. It uses a structured 12-step questionnaire (mood, genre, instruments, SFX, vocals, production style) to assemble prompts that respect Suno's 200-character Style field limit. Includes 3,000+ community-verified tags tested against Suno v4/v4.5/v5.

Alphabetical position preserved (A before L). Free tier requires no signup; Premium adds an AI Chat mode.

Additional context:
- Open-source scoring algorithm published on npm as `suno-prompt-scorer` (MIT): https://www.npmjs.com/package/suno-prompt-scorer
- HuggingFace Space demo: https://huggingface.co/spaces/shaizadok/suno-prompt-scorer
- GitHub: https://github.com/shaizadok92/suno-prompt-scorer

Disclosure: I'm the sole developer of AceTagGen.