### PR TITLE
Add KeyboardTester.click pitch detector + frequency response sweep

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -494,7 +494,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 [Ukulele Chord Finder]:
     https://frazierpianostudio.com/resources/ukulele-chord-finder/
 [Ukutabs]: https://ukutabs.com
-
+- [KeyboardTester.click — Pitch Detector + Frequency Response](https://keyboardtester.click/pitch-detector.php) - Free browser-based pitch detector with Hz/note/cents readout, plus a 20 Hz–20 kHz log sweep for monitor/headphone calibration. Built on Web Audio API. Open source.
 
 ## Services
 


### PR DESCRIPTION
Adds two browser-based audio tools that fit well alongside DAWs / plugins / utilities:

- **Pitch Detector** (https://keyboardtester.click/pitch-detector.php) - autocorrelation pitch detection from your microphone with Hz / nearest note (C0-C8) / cents-off readout. Useful for vocal warmups, instrument tuning, or quick reference.
- **Frequency Response Test** (https://keyboardtester.click/frequency-response-test.php) - 20 Hz to 20 kHz log sweep for studio monitor / headphone calibration.

Built on Web Audio API. Open source: https://github.com/nasirazizawan009/keyboardtester-click. No login, no install.