### PR TITLE
Add HookGenius to AI Music Creation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -545,6 +545,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 
 ### AI Music Creation
 
+- [HookGenius] - AI lyrics and style prompt generator for Suno; produces copy-paste-ready hooks, song structures, and genre-tuned style tags.
 - [LAIVE]
 - [LatentScore Live] - Generate ambient music from text in the browser.
 - [MemoTune] - Transform text or lyrics into full songs with AI vocals.
@@ -553,6 +554,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 - [Splash] - AI-powered music creation platform.
 - [Suno AI] - AI-powered music composition and production platform.
 
+[HookGenius]: https://hookgenius.app
 [LAIVE]: https://www.laive.io
 [LatentScore Live]: https://latentscore.com
 [MemoTune]: https://memotune.com


### PR DESCRIPTION
Adding [HookGenius](https://hookgenius.app) to the **AI Music Creation** section.

**What it is:** An AI-powered lyrics and style prompt generator built specifically for Suno music creators. Produces copy-paste-ready hooks, full song structures, and genre-tuned style tags with artist-style references. Uses Claude Sonnet for generation; respects Suno's character limits and metatag conventions.

**Why it fits this section:** It complements Suno AI (already listed) by solving the upstream prompt-engineering problem — the actual songwriting input that Suno generates from. Same use case context as the other entries (LatentScore Live, MemoTune, Splash, Suno AI itself).

**Format:** Followed the section's reference-style link pattern. Inserted alphabetically before LAIVE; reference link added to the alphabetically-sorted reference block.

**Disclosure:** I'm the maintainer of HookGenius. Submitting because the tool genuinely fits this section's existing curation pattern (other Suno-adjacent tools like Splash and Suno AI itself are listed here). Happy to adjust description length/wording if you'd prefer a tighter line.

Thanks for maintaining this list.