### PR TITLE
Add MoveMusic to Music Promotion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -589,8 +589,10 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 
 ### Music Promotion
 
+- [MoveMusic] - AI-powered sync licensing and music promotion platform connecting artists with TV, film, and brand opportunities.
 - [SubmitHub] - Submit your music to bloggers and curators.
 
+[MoveMusic]: https://movemusic.alldayautomations.ai
 [SubmitHub]: https://www.submithub.com
 
 


### PR DESCRIPTION
## What

Add [MoveMusic](https://movemusic.alldayautomations.ai) to the Music Promotion section.

## Why

MoveMusic is an AI-powered platform that helps independent musicians and producers land sync licensing deals with TV, film, games, and brands. It directly complements SubmitHub (pitching to bloggers/curators) by targeting a different promotion channel — sync placements.

Fits the list's focus on software and services for music production professionals.