### PR TITLE
Add demucs-onnx to Libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ A curated list of software, hardware, and other resources to create music.
 - [Blip] - Looping and sampling with the Web Audio API.
 - [Cane] - A small MIDI sequencer DSL designed around vectors and euclidean rhythms.
 - [CSound] - A sound and music computing system.
+- [demucs-onnx] - Run and export HT-Demucs music source separation as ONNX (pure numpy + onnxruntime, no PyTorch at inference).
 - [Dplug] - Library to make audio plug-ins with the D programming language.
 - [Euterpea] - In Haskell embedded language for computer music applications.
 - [Faust] - Functional programming language
@@ -186,6 +187,7 @@ A curated list of software, hardware, and other resources to create music.
 [Blip]: https://jshanley.github.io/blip/
 [Cane]: https://github.com/tarpit-collective/cane
 [CSound]: https://csound.com/index.html
+[demucs-onnx]: https://github.com/StemSplit/demucs-onnx
 [Dplug]: https://github.com/AuburnSounds/dplug
 [Euterpea]: https://www.euterpea.com/
 [Faust]: https://faust.grame.fr


### PR DESCRIPTION
Adds `demucs-onnx` to the Libraries section, between `CSound` and `Dplug` alphabetically.

[`demucs-onnx`](https://github.com/StemSplit/demucs-onnx) is a pip-installable Python package + pre-built ONNX models for HT-Demucs (the architecture behind Meta's [`demucs`](https://github.com/facebookresearch/demucs) source separation paper). Sits alongside `Spleeter` in scope (the existing entry on line 167), but exports and runs as ONNX so it deploys without PyTorch — relevant for music-production tooling that wants stem separation in a plug-in, mobile app, or browser without bundling a 2 GB DL framework.

- License: MIT.
- PyPI: <https://pypi.org/project/demucs-onnx/>
- Docs: <https://stemsplit.github.io/demucs-onnx/>

Following the alphabetical convention used in the section.

Made with [Cursor](https://cursor.com)