### PR TITLE
Add The Mix Medic to SaaS (mastering)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -496,7 +496,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 ### SaaS
 
 - [Landr] - Automatic audio mastering. $
-- [The Mix Medic] - In-browser AI mastering with reference matching. First master free. $
+- [The Mix Medic] - In-browser AI mastering with reference matching. $
 - [Virtu] - Assisted mastering. $
 
 [Landr]: https://www.landr.com

--- a/readme.md
+++ b/readme.md
@@ -496,9 +496,11 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 ### SaaS
 
 - [Landr] - Automatic audio mastering. $
+- [The Mix Medic] - In-browser AI mastering with reference matching. First master free. $
 - [Virtu] - Assisted mastering. $
 
 [Landr]: https://www.landr.com
+[The Mix Medic]: https://themixmedic.com
 [Virtu]: https://virtu.slatedigital.com
 
 


### PR DESCRIPTION
Adds [The Mix Medic](https://themixmedic.com) to the SaaS section alongside the other online mastering services (Landr, Virtu).

The Mix Medic is a browser-based AI audio mastering service with reference matching and genre engines, built by an LA mastering engineer. There is a free tier (first master free) plus paid options, so it is marked $ to match the section convention.

Entry kept short and placed alphabetically between Landr and Virtu, following the existing reference-link format. Thanks for the list!