### PR TITLE
Add Reverie to Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -333,6 +333,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 - [Ossia Score] - Sequencer for audio-visual and interactive shows.
 - [Patroneo] - Simple pattern based midi sequencer.
 - [Polyphone] - A soundfont editor for quickly designing musical instruments.
+- [Reverie] - Desktop app that transforms audio files into evolving ambient textures and drones (macOS and Windows). $
 - [Samplr] - Multi-touch music making app for iPad. $
 - [SeekMIDI] - Graphical multi channel MIDI sequencer.
 - [Seq24] - Minimal loop based midi sequencer.
@@ -370,6 +371,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 [Ossia Score]: https://ossia.io
 [Patroneo]: https://laborejo.org/patroneo/
 [Polyphone]: https://www.polyphone.io/
+[Reverie]: https://reverie.parallel-minds.studio
 [Samplr]: http://samplr.net
 [SeekMIDI]: https://oldtechaa.github.io/SeekMIDI/
 [Seq24]: https://filter24.org/seq24/


### PR DESCRIPTION
Adds [Reverie](https://reverie.parallel-minds.studio) to the **Software → Apps** section (alphabetically, between Polyphone and Samplr).

Reverie is a desktop app (macOS and Windows) that transforms audio files into evolving ambient textures and drones through randomized effect chains. Paid software, marked with `$` per the list convention.

Two changes, both in `readme.md`: the list entry and the matching reference-style link definition.