### PR TITLE
Add GuitarToneAdapt to Software > Guitar, Ukulele

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -533,6 +533,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 - [Chordata] - A dummy chord-book for mandolin, ukulele and guitar.
 - [Fretboard] - Online Guitar fretboard viewer to study scales and chords.
 - [Guitarix] - Virtual guitar amplifier for Linux running on JACK.
+- [GuitarToneAdapt] - Re-dials any famous song's amp and EQ settings for the exact guitar, amp and pickups you own. Free, in the browser.
 - [Karplus-Strong Guitar] - JavaScript implementation of the Karplus-Strong
     plucked string synthesis algorithm.
 - [SmartGuitarAmp] - Guitar plugin using neural networks
@@ -548,6 +549,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 [Chordata]: https://github.com/starenka/chordata
 [Fretboard]: https://github.com/AlexMost/fretboard
 [Guitarix]: https://guitarix.org
+[GuitarToneAdapt]: https://guitartoneadapt.com
 [Karplus-Strong Guitar]: https://amid.fish/javascript-karplus-strong
 [SmartGuitarAmp]: https://github.com/GuitarML/SmartGuitarAmp
 [UkeGeeks]: https://github.com/buzcarter/UkeGeeks

--- a/readme.md
+++ b/readme.md
@@ -533,7 +533,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 - [Chordata] - A dummy chord-book for mandolin, ukulele and guitar.
 - [Fretboard] - Online Guitar fretboard viewer to study scales and chords.
 - [Guitarix] - Virtual guitar amplifier for Linux running on JACK.
-- [GuitarToneAdapt] - Re-dials any famous song's amp and EQ settings for the exact guitar, amp and pickups you own. Free, in the browser.
+- [GuitarToneAdapt] - Re-dial any famous song's amp and EQ settings for the exact guitar, amp, and pickups you own.
 - [Karplus-Strong Guitar] - JavaScript implementation of the Karplus-Strong
     plucked string synthesis algorithm.
 - [SmartGuitarAmp] - Guitar plugin using neural networks


### PR DESCRIPTION
Adds **GuitarToneAdapt** under Software > Guitar, Ukulele.

It's a free, no-signup web tool that takes the original amp/EQ/gain settings of famous guitar tones and re-dials them for the exact guitar, amp and pickups you own (compensating for pickup output, brightness and amp voicing). Fits alongside the other guitar tools; entry + reference link placed alphabetically, follows the existing format.