### PR TITLE
Add ToneTwin to Guitar section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -538,6 +538,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
     plucked string synthesis algorithm.
 - [SmartGuitarAmp] - Guitar plugin using neural networks
     to emulate real world hardware.
+- [ToneTwin] - Find the amp, pedal, and EQ settings behind any song and adapt them to your own guitar, amp, and pedals.
 - [UkeGeeks] - Creates fingering diagrams by reading plain text
     or ChordPro ukulele songs.
 - [Ukulele Chord Detector] - Website for identifying chords
@@ -552,6 +553,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 [GuitarToneAdapt]: https://guitartoneadapt.com
 [Karplus-Strong Guitar]: https://amid.fish/javascript-karplus-strong
 [SmartGuitarAmp]: https://github.com/GuitarML/SmartGuitarAmp
+[ToneTwin]: https://tone-twin.com
 [UkeGeeks]: https://github.com/buzcarter/UkeGeeks
 [Ukulele Chord Detector]: https://ukealong.com/tool/chord-detector/
 [Ukulele Chord Finder]:


### PR DESCRIPTION
Adds **ToneTwin** to the Guitar, Ukulele section.

It finds the amp, pedal and EQ settings behind any song and adapts them to your own guitar, amp and pedals. It sits naturally alongside the existing GuitarToneAdapt entry in the same section. Available on web and iOS.

- Entry added in alphabetical order (after SmartGuitarAmp, before UkeGeeks)
- Reference link added to match the list's link style