### PR TITLE
Add Track Finder to Webapps section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -435,10 +435,10 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 - [SongFromLink] - Identify background music from TikTok, YouTube Shorts, Instagram Reels, X, and Facebook Reels video links
 - [TimeStretch] - Online tool to loop, speed up, slow down, and pitch shift sections of an audio file.
 - [Tap Tempo] - Free Tap BPM tool that actually syncs with your hardware (Web MIDI).
+- [Track Finder] - Paste a tracklist or YouTube playlist URL and get per-track search links on nine platforms, including SoundCloud, Spotify, Bandcamp, and Beatport.
 - [Vizz.fm] - Browser-based music visualizer with customizable scenes and savable presets.
 - [Web Theremin] - Browser-based theremin instrument.
 - [Tonalux] - Free browser-based audio tools: spectrum analyzer, plugin comparer, and media converter.
-- [Track Finder] - Paste a tracklist or YouTube playlist URL and get per-track search links on SoundCloud, Spotify, YouTube, Apple Music, and Beatport.
 - [Websynths] - Free browser-based microtonal midi instrument.
 - [WhatChord] - Real-time MIDI chord recognition with an explore mode for building chords.
 

--- a/readme.md
+++ b/readme.md
@@ -438,6 +438,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 - [Vizz.fm] - Browser-based music visualizer with customizable scenes and savable presets.
 - [Web Theremin] - Browser-based theremin instrument.
 - [Tonalux] - Free browser-based audio tools: spectrum analyzer, plugin comparer, and media converter.
+- [Track Finder] - Paste a tracklist or YouTube playlist URL and get per-track search links on SoundCloud, Spotify, YouTube, Apple Music, and Beatport.
 - [Websynths] - Free browser-based microtonal midi instrument.
 - [WhatChord] - Real-time MIDI chord recognition with an explore mode for building chords.
 
@@ -493,6 +494,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 [TimeStretch]: https://29a.ch/timestretch/
 [Tap Tempo]: https://tapbpmhub.com/
 [Tonalux]: https://tonalux.org
+[Track Finder]: https://track-finder.vercel.app
 [Vizz.fm]: https://vizz.fm
 [Web Theremin]: https://hat-and-beard.itch.io/web-theremin
 [Websynths]: https://www.websynths.com/


### PR DESCRIPTION
Adds [Track Finder](https://track-finder.vercel.app) to the Webapps section.

Paste a tracklist or a YouTube playlist/mix URL and get a per-track search link on nine platforms (SoundCloud, Spotify, YouTube, Apple Music, Beatport, Tidal, Bandcamp, Deezer, Mixcloud). Useful for crate-digging tracks out of DJ sets and YouTube mixes.

Closest existing entry is SongFromLink, which identifies unknown audio in short-form videos. Track Finder starts from a known tracklist and resolves each line to search links, so the two don't overlap, and nothing else in the list does tracklist conversion.

Free, open source (MIT), no account required. The app is a single HTML file plus one serverless function for the YouTube playlist import. I'm the author. Source: https://github.com/conorbronsdon/track-finder

- Entry placed alphabetically after Tap Tempo, before Vizz.fm
- Reference link added alphabetically to match the list's link style