### PR TITLE
Add Cadence to Webapps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -395,6 +395,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 - [beatboxer] - Simple drum machine.
 - [Binary Synth] - Binary file interpreter for audio synthesis.
 - [BlokDust] - Interactive music-making app to build synths and sounds.
+- [Cadence] - Vocal training with real-time pitch detection, range and voice-type tests, and sight-singing drills.
 - [Chord Editor] - Edit chord diagrams for guitar, ukulele, and other fretted instruments.
 - [Chords] - Text based chord progression editor.
 - [Chorushive] - Real-time Spotify lyric display with 8 visual themes and WebGL animated backgrounds.
@@ -452,6 +453,7 @@ Find more resources at [Awesome Livecoding] - A curated list of live coding lang
 [beatboxer]: https://sig.gy/beatboxer/
 [Binary Synth]: https://github.com/MaxAlyokhin/binary-synth
 [BlokDust]: https://github.com/blokdust/blokdust
+[Cadence]: https://cadencetutor.com
 [Chord Editor]: https://github.com/newlandsvalley/chord-editor
 [Chords]: https://github.com/evashort/chords
 [Chorushive]: https://github.com/Greg-RG-GIT/chorushive


### PR DESCRIPTION
https://cadencetutor.com

Vocal training that runs in the browser. It draws your pitch in real time as you sing, so you can see where you scoop into a note, where you drift on a long one and how steady the pitch actually is. There are free vocal range, voice type, tone-deaf, perfect pitch and vibrato tests, plus a sight-singing trainer and MusicXML import for learning a part.

Pitch detection is autocorrelation with parabolic interpolation running in an AudioWorklet, so everything is client-side, no audio is uploaded and the tests need no sign-up.

Two insertions, both kept alphabetical: the bullet in Webapps between BlokDust and Chord Editor, and the matching reference definition in the link block below it.